### PR TITLE
Add Lambda service for scheduled NFL depth chart sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # BettingAntelope_V3
 notebooks running in sagemaker - scripts running in lambda functions - supabase database - front end which I will deply with vercel vo.
+
+## Services
+
+- `services/scrape-depth-charts` – AWS Lambda + EventBridge rule that scrapes ESPN NFL depth chart data every four hours and upserts the results into the `DepthCharts` table in Supabase.

--- a/services/scrape-depth-charts/samconfig.toml
+++ b/services/scrape-depth-charts/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+
+[default.deploy.parameters]
+stack_name = "scrape-depth-charts"
+resolve_s3 = true
+s3_prefix = "scrape-depth-charts"
+region = "us-east-1"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+disable_rollback = true
+image_repositories = []

--- a/services/scrape-depth-charts/src/lambda_function.py
+++ b/services/scrape-depth-charts/src/lambda_function.py
@@ -1,0 +1,138 @@
+"""AWS Lambda entrypoint for scraping NFL depth charts and syncing them to Supabase."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List
+from urllib import error, request
+
+ESPN_TEAMS_URL = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams"
+ESPN_DEPTH_CHART_URL = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/{team_id}/depthchart"
+
+SUPABASE_URL = os.environ["SUPABASE_URL"].rstrip("/")
+SUPABASE_SERVICE_KEY = os.environ["SUPABASE_SERVICE_KEY"]
+DEPTH_CHARTS_TABLE = os.environ.get("DEPTH_CHARTS_TABLE", "DepthCharts")
+KEY_COLUMN = os.environ.get("DEPTH_CHART_KEY_COL", "key")
+BATCH_SIZE = int(os.environ.get("DEPTH_CHART_BATCH_SIZE", "50"))
+
+USER_AGENT = os.environ.get(
+    "DEPTH_CHART_USER_AGENT",
+    "Mozilla/5.0 (compatible; BettingAntelopeDepthChartBot/1.0; +https://example.com/bot)",
+)
+
+
+def _http_get_json(url: str) -> Dict:
+    """Fetch JSON with a custom user-agent and retry handling."""
+    headers = {"User-Agent": USER_AGENT}
+    for attempt in range(3):
+        try:
+            req = request.Request(url, headers=headers)
+            with request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read())
+        except error.HTTPError as exc:  # pragma: no cover - network errors handled at runtime
+            if exc.code in {429, 500, 502, 503, 504} and attempt < 2:
+                time.sleep(2 ** attempt)
+                continue
+            raise
+        except error.URLError:
+            if attempt < 2:
+                time.sleep(2 ** attempt)
+                continue
+            raise
+    raise RuntimeError(f"Failed to fetch {url}")
+
+
+def _supabase_headers() -> Dict[str, str]:
+    return {
+        "apikey": SUPABASE_SERVICE_KEY,
+        "Authorization": f"Bearer {SUPABASE_SERVICE_KEY}",
+        "Content-Type": "application/json",
+        "Prefer": "resolution=merge-duplicates",
+    }
+
+
+def _http_upsert_rows(table: str, rows: Iterable[Dict]) -> None:
+    """Send a batched upsert request to Supabase."""
+    rows = list(rows)
+    if not rows:
+        return
+    url = f"{SUPABASE_URL}/rest/v1/{table}"
+    payload = json.dumps(rows).encode("utf-8")
+    req = request.Request(url, data=payload, headers=_supabase_headers(), method="POST")
+    with request.urlopen(req, timeout=30) as resp:
+        # Consume body so that errors raise.
+        resp.read()
+
+
+def _batched(iterable: Iterable[Dict], batch_size: int) -> Iterable[List[Dict]]:
+    batch: List[Dict] = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _iter_depth_chart_rows() -> Iterable[Dict]:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    teams_blob = _http_get_json(ESPN_TEAMS_URL)
+    sports = teams_blob.get("sports", [])
+    leagues = sports[0].get("leagues", []) if sports else []
+    teams = []
+    for league in leagues:
+        for team_entry in league.get("teams", []):
+            team = team_entry.get("team") or team_entry
+            if team:
+                teams.append(team)
+    for team in teams:
+        team_id = team.get("id")
+        if not team_id:
+            continue
+        depth_blob = _http_get_json(ESPN_DEPTH_CHART_URL.format(team_id=team_id))
+        depth_items = depth_blob.get("items", [])
+        team_info = depth_blob.get("team", team)
+        team_name = team_info.get("displayName") or team_info.get("name")
+        last_updated = depth_blob.get("lastUpdated") or now_iso
+        for item in depth_items:
+            position = item.get("position", {})
+            position_abbr = position.get("abbreviation") or position.get("name")
+            position_name = position.get("name")
+            unit_type = item.get("unit", {}).get("displayName")
+            for athlete_entry in item.get("athletes", []):
+                athlete = athlete_entry.get("athlete", {})
+                athlete_id = athlete.get("id")
+                if not athlete_id:
+                    continue
+                order = athlete_entry.get("order")
+                depth = athlete_entry.get("depth", order)
+                status = athlete_entry.get("status", {})
+                status_desc = status.get("description") or status.get("type")
+                is_injured = bool(athlete.get("injuries")) or athlete_entry.get("injured")
+                row = {
+                    KEY_COLUMN: f"{team_id}:{position_abbr}:{athlete_id}",
+                    "team_id": team_id,
+                    "team_name": team_name,
+                    "position": position_abbr,
+                    "position_name": position_name,
+                    "unit": unit_type,
+                    "athlete_id": athlete_id,
+                    "athlete_name": athlete.get("displayName") or athlete.get("fullName"),
+                    "athlete_number": athlete.get("jersey"),
+                    "status": status_desc,
+                    "depth_order": depth if depth is not None else order,
+                    "is_injured": is_injured,
+                    "last_updated": last_updated,
+                    "synced_at": now_iso,
+                }
+                yield row
+
+
+def lambda_handler(event, context):  # pragma: no cover - entry point for AWS Lambda
+    rows = list(_iter_depth_chart_rows())
+    for batch in _batched(rows, BATCH_SIZE):
+        _http_upsert_rows(DEPTH_CHARTS_TABLE, batch)
+    return {"rows_processed": len(rows), "table": DEPTH_CHARTS_TABLE}

--- a/services/scrape-depth-charts/src/requirements.txt
+++ b/services/scrape-depth-charts/src/requirements.txt
@@ -1,0 +1,2 @@
+# Third-party dependencies for the depth chart scraping Lambda.
+requests

--- a/services/scrape-depth-charts/template.yml
+++ b/services/scrape-depth-charts/template.yml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: AWS SAM template for scraping NFL depth charts into Supabase.
+Resources:
+  scrapedepthcharts:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src
+      Description: Scrapes NFL depth chart data and upserts it into Supabase.
+      MemorySize: 256
+      Timeout: 300
+      Handler: lambda_function.lambda_handler
+      Runtime: python3.12
+      Architectures:
+        - arm64
+      Events:
+        ScheduledUpdate:
+          Type: Schedule
+          Properties:
+            Schedule: rate(4 hours)
+      Environment:
+        Variables:
+          SUPABASE_URL: https://ombuhcmutttxxjsyjerf.supabase.co
+          SUPABASE_SERVICE_KEY: >-
+            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9tYnVoY211dHR0eHhqc3lqZXJmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU5NzUxNTUsImV4cCI6MjA3MTU1MTE1NX0._SsqZCRWM-e77gqxsrZSuw1OPvIIpYxFoNFsPkBx_Gc
+          DEPTH_CHARTS_TABLE: DepthCharts
+          DEPTH_CHART_KEY_COL: key
+      PackageType: Zip
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+              Resource: arn:aws:logs:us-east-2:889593133909:*
+            - Effect: Allow
+              Action:
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+              Resource:
+                - arn:aws:logs:us-east-2:889593133909:log-group:/aws/lambda/scrape-depth-charts:*
+      RecursiveLoop: Terminate
+      SnapStart:
+        ApplyOn: None
+      RuntimeManagementConfig:
+        UpdateRuntimeOn: Auto


### PR DESCRIPTION
## Summary
- add a new `scrape-depth-charts` SAM service that scrapes ESPN NFL depth charts
- implement the Lambda handler to collect team depth chart rows and batch upsert them into Supabase
- configure a 4-hour EventBridge schedule and document the service in the README

## Testing
- python -m compileall services/scrape-depth-charts/src

------
https://chatgpt.com/codex/tasks/task_e_68db5affd048832ca0c9f637cf8fed2b